### PR TITLE
Delete old 'dcs_courses' value.

### DIFF
--- a/duolingo-course-switcher.user.js
+++ b/duolingo-course-switcher.user.js
@@ -43,8 +43,12 @@ function updateCourses(A) {
     var courses = JSON.parse(GM_getValue('dcs_courses', '{}'));
     var learning = [].filter.call(A.languages, function(lang){ return lang.learning; });
     courses[A.ui_language] = learning.map(function(lang){ return _(lang).pick('language', 'level'); });
-    GM_deleteValue('dcs_courses');
-    GM_setValue('dcs_courses', JSON.stringify(courses));
+    try {
+        GM_deleteValue('dcs_courses');
+    }
+    finally {
+        GM_setValue('dcs_courses', JSON.stringify(courses));
+    }
     return courses;
 }
 

--- a/duolingo-course-switcher.user.js
+++ b/duolingo-course-switcher.user.js
@@ -9,6 +9,7 @@
 // @require     http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js
 // @grant       GM_getValue
 // @grant       GM_setValue
+// @grant       GM_deleteValue
 // @author      arekolek, mofman, gmelikov, christeefury, guillaumebrunerie
 // ==/UserScript==
 
@@ -42,6 +43,7 @@ function updateCourses(A) {
     var courses = JSON.parse(GM_getValue('dcs_courses', '{}'));
     var learning = [].filter.call(A.languages, function(lang){ return lang.learning; });
     courses[A.ui_language] = learning.map(function(lang){ return _(lang).pick('language', 'level'); });
+    GM_deleteValue('dcs_courses');
     GM_setValue('dcs_courses', JSON.stringify(courses));
     return courses;
 }


### PR DESCRIPTION
This is probably a Greasemonkey bug, but when you set a value with GM_setValue, the old value isn't deleted. The old values just pile up. If you check <firefox's folder>/gm_scripts/DuoLingo_Course_Switcher.db, you should see lots of extraneaous old values in the database.

This patch fixes this by deleting the old value just before setting the new value.

EDIT: It might be advisable to wrap the delete statement in an if statement to make sure 'dcs_courses' actually exists. I doubt it really causes any issues, but it will raise a warning if it doesn't exist.

Also, I'm wondering if it's possible to put the GM_setValue in a "finally" clause just in case there's an error or break before it gets set. I had this happen to me once and it cleared the old value without setting the new. It's probably pretty rare since it took weeks to happen to me and I'm refreshing the pages quite a bit since I'm porting this script to the new site.

EDIT2: Just committed all that. It should be more robust now.